### PR TITLE
Indicator Component Added

### DIFF
--- a/compass/components/ui/Indicator/IndicatorCard.tsx
+++ b/compass/components/ui/Indicator/IndicatorCard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+// Importing the structure of the component 
+import { Indicator } from './indicators.types';
+
+interface IndicatorCardProps {
+  data: Indicator;
+}
+// This component expects a data which must match the Indicator interface, title, value and optional actions
+
+const IndicatorCard: React.FC<IndicatorCardProps> = ({ data }) => {
+    // extracting the details from the input data
+  const { title, value, actions } = data;
+  return (
+    <div className="min-w-[220px] bg-white rounded-2xl shadow-md p-4 flex flex-col justify-between border border-gray-200 transition hover:shadow-lg">
+      <div>
+        {/* Display the title and the value */}
+        <p className="text-gray-900 text-lg font-bold">{title}</p>
+        <p className="text-xl font-medium text-gray-700">{value}</p>
+      </div>
+    {/* If we have some actions, we execute the below */}
+      {actions && actions.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2 justify-center    ">
+            {/* Takes the first 3 actions, action is the individual object having icon,text,onclick function, and index is the unique key for React */}
+          {actions.slice(0, 3).map((action, index) => (
+
+            <button
+              key={index}
+              onClick={action.onClick}
+              className="flex icons-center gap-2 text-sm bg-blue-600 text-white px-2 py-1 rounded-md hover:opacity-80 transition-opacity"
+              >
+                {/* Span renders the icon component, then the text label */}
+              <span >{action.icon}</span>
+              <span>{action.text}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IndicatorCard;
+// data object will have an array named actions, which is going to contain icon, text, and the onclick function, if it exists. 
+// For flexibility, we don't write any onclick function here, but allow it to be passed as the input

--- a/compass/components/ui/Indicator/Indicators.tsx
+++ b/compass/components/ui/Indicator/Indicators.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// Indicator type and Indicator card being imported
+import IndicatorCard from './IndicatorCard';
+import { Indicator } from './indicators.types';
+
+interface IndicatorsProps {
+  indicators: Indicator[];
+}
+// React function component
+const Indicators: React.FC<IndicatorsProps> = ({ indicators }) => {
+  return (
+    // overflow makes the row horizontally scrollable
+    <div className="overflow-x-auto w-full py-2">
+      <div className="flex gap-4 min-w-max px-4">
+        {/* Loops through each Indicator object, and renders a card for each */}
+        {indicators.map((indicator, index) => (
+          <IndicatorCard key={index} data={indicator} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Indicators;

--- a/compass/components/ui/Indicator/indicators.types.ts
+++ b/compass/components/ui/Indicator/indicators.types.ts
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+export interface IndicatorAction {
+    // ReactNode is a type from React that represents anything React can render
+  icon: ReactNode;          // Icon component (e.g., from Lucide or Heroicons)
+  text: string;             // Label for the action
+// void means that the function does not takes any arguments, and returns nothing
+  onClick: () => void;      // Function to execute
+}
+
+export interface Indicator {
+  title: string;            // E.g., "Active Users"
+  value: string | number;   // E.g., "2.4K"
+//   ? means that it's optional, a card can be made without actions array
+  actions?: IndicatorAction[]; // Optional array (max 3 actions)
+}


### PR DESCRIPTION
Added a folder having all the required files for the Indicator Component.

1. indicator.types.ts -> has the structure for the indicator cards
2. IndicatorCard.tsx -> gives the basic structure for the Indicator Card
3. Indicators.tsx -> finally renders a horizontally scroll-able set of Indicator Cards

Everything, including the action buttons (Along with their icons, text, function to be executed on tap etc.) are supposed to be send as the input, this is just used to render the Cards. 